### PR TITLE
fix: line break on faucet list and book title

### DIFF
--- a/articles/03_account.md
+++ b/articles/03_account.md
@@ -100,10 +100,12 @@ Symbolブロックチェーンでは、この手数料をXYMという共通ト�
 メインネットの場合は取引所などでXYMを購入するか、投げ銭サービス(NEMLOG,QUEST)などを利用して寄付を募りましょう。  
 
 テストネット
+
 - FAUCET(蛇口)
   - https://testnet.symbol.tools/
 
 メインネット
+
 - NEMLOG
   - https://nemlog.nem.social/
 - QUEST

--- a/articles/config.yml
+++ b/articles/config.yml
@@ -17,12 +17,12 @@ review_version: 5.0
 # inherit: ["A.yml", "B.yml"]
 
 # ブック名(ファイル名になるもの。ASCII範囲の文字を使用)
-bookname: Quick-Learning-Symbol
+bookname: Quick-Learning-Symbol-JS
 # 記述言語。省略した場合はja
 language: ja
 
 # 書名
-booktitle: {name: "今日から現場で使える速習Symbolブロックチェーン", file-as: "キョウカラゲンバデツカエルソクシュウsymbolブロックチェーン"}
+booktitle: {name: "今日から現場で使える速習SymbolブロックチェーンJavaScript版", file-as: "キョウカラゲンバデツカエルソクシュウSymbolブロックチェーンJavaScriptバン"}
 
 # 著者名。「, 」で区切って複数指定できる
 aut: [{name: "XEMBook", file-as: "xembook"}]


### PR DESCRIPTION
- page19  「3.2.1 フォーセットから送信」のリストが改行されていない問題の修正
- booktitleの変更 toshiさんのC#版とわかりやすく判別できるよう「JavaScript版」と明示的に追記